### PR TITLE
Auth | Implemented Admin register and check token

### DIFF
--- a/v1/models/auth.js
+++ b/v1/models/auth.js
@@ -59,68 +59,197 @@ const auth = {
 
         // Find the email in database
         let client = new MongoClient(mongoURI);
-        let db = client.db("spark-rentals");
-        let admins_collection = db.collection("admins");
-        let admin = await admins_collection.findOne({email: adminEmail});
+        try {
+            let db = client.db("spark-rentals");
+            let admins_collection = db.collection("admins");
+            let admin = await admins_collection.findOne({email: adminEmail});
 
-        // If email not found in database
-        if (admin === null) {
+            // If email not found in database
+            if (admin === null) {
+                return res.status(401).json({
+                    errors: {
+                        status: 401,
+                        source: "/auth/admin/login",
+                        title: "Admin not found",
+                        detail: "Admin with provided email not found."
+                    }
+                });
+            }
+
+            // Compare bcrypt password in database with password sent in.
+            bcrypt.compare(adminPassword, admin.password, (err, result) => {
+                if (err) {
+                    return res.status(500).json({
+                        errors: {
+                            status: 500,
+                            source: "/auth/admin/login",
+                            title: "bcrypt error",
+                            detail: "bcrypt error"
+                        }
+                    });
+                }
+
+                // If everything goes allright it created jwt token and send a response sucess with jwt token
+                if (result) {
+                    let payload = { api_key: apiKey, email: admin.email };
+                    let jwtToken = jwt.sign(payload, jwtSecret, { expiresIn: '24h' });
+
+                    return res.json({
+                        data: {
+                            type: "success",
+                            message: "Admin logged in",
+                            user: payload,
+                            token: jwtToken
+                        }
+                    });
+                }
+
+                // If password is not the same as in database
+                return res.status(401).json({
+                    errors: {
+                        status: 401,
+                        source: "/auth/admin/login",
+                        title: "Wrong password",
+                        detail: "Password is incorrect."
+                    }
+                });
+            });
+        } catch(e) {
+            console.log(e);
+        } finally {
+            await client.close();
+        }
+    },
+
+    adminRegister: async function(res, body) { // Register a new Admin
+        const adminEmail = sanitize(body.email);
+        const adminPassword = sanitize(body.password);
+        const adminFirstName = sanitize(body.firstName);
+        const adminLastName = sanitize(body.lastName);
+
+        if (!adminEmail || !adminPassword) {
             return res.status(401).json({
                 errors: {
                     status: 401,
-                    source: "/auth/admin/login",
-                    title: "Admin not found",
-                    detail: "Admin with provided email not found."
+                    source: "/auth/admin/register",
+                    title: "Email or password missing",
+                    detail: "Email or password missing in request"
+                }
+            });
+        } else if (!adminFirstName || !adminLastName) {
+            return res.status(401).json({
+                errors: {
+                    status: 401,
+                    source: "/auth/admin/register",
+                    title: "First name or last name missing",
+                    detail: "First name or last name missing in request"
                 }
             });
         }
 
-        // Compare bcrypt password in database with password sent in.
-        bcrypt.compare(adminPassword, admin.password, (err, result) => {
-            if (err) {
-                return res.status(500).json({
+        // Find the email in database
+        let client = new MongoClient(mongoURI);
+        try {
+            let db = client.db("spark-rentals");
+            let admins_collection = db.collection("admins");
+            let admin = await admins_collection.findOne({email: adminEmail});
+
+            // If email found in database
+            if (admin !== null) {
+                return res.status(401).json({
                     errors: {
-                        status: 500,
-                        source: "/auth/admin/login",
-                        title: "bcrypt error",
-                        detail: "bcrypt error"
+                        status: 401,
+                        source: "/auth/admin/register",
+                        title: "Admin alredy created",
+                        detail: "Admin with provided email is alredy created in database."
                     }
                 });
             }
 
-            // If everything goes allright it created jwt token and send a response sucess with jwt token
-            if (result) {
-                let payload = { api_key: apiKey, email: admin.email };
-                let jwtToken = jwt.sign(payload, jwtSecret, { expiresIn: '24h' });
+            bcrypt.hash(adminPassword, 10, async function(err, hash) {
+                if (err) {
+                    return res.status(500).json({
+                        errors: {
+                            status: 500,
+                            source: "/auth/admin/register",
+                            title: "bcrypt error",
+                            detail: "bcrypt error"
+                        }
+                    });
+                }
+    
+                adminCreate = {
+                    firstName: adminFirstName,
+                    lastName: adminLastName,
+                    email: adminEmail,
+                    password: hash,
+                }
+    
+                let clientRegister = new MongoClient(mongoURI);
+                try {
+                    let db = clientRegister.db("spark-rentals");
+                    let admins_collection = db.collection("admins");
+                    await admins_collection.insertOne(adminCreate);
 
-                return res.json({
+                    return res.status(201).json({
+                        data: {
+                            message: "User successfully registered."
+                        }
+                    });
+                } catch(e) {
+                    console.log(e);
+                } finally {
+                    await clientRegister.close();
+                }
+
+                return res.status(500).json({
                     data: {
-                        type: "success",
-                        message: "Admin logged in",
-                        user: payload,
-                        token: jwtToken
+                        message: "Database error path: /auth/admin/register"
                     }
                 });
-            }
+            });
+        } catch(e) {
+            console.log(e);
+        } finally {
+            await client.close();
+        }
+    },
 
-            // If password is not the same as in database
+    adminCheckToken: function(req, res, next) { // Check the x-access-token from admin (Not need for user bcs it uses passport)
+        let token = req.headers['x-access-token'];
+
+        if (token) {
+            jwt.verify(token, jwtSecret, function(err, decoded) {
+                if (err) {
+                    return res.status(500).json({
+                        errors: {
+                            status: 500,
+                            source: req.path,
+                            title: "Failed authentication",
+                            detail: err.message
+                        }
+                    });
+                }
+
+                req.admin = {};
+                req.admin.api_key = decoded.api_key;
+                req.admin.email = decoded.email;
+
+                next();
+
+                return undefined;
+            });
+        } else {
             return res.status(401).json({
                 errors: {
                     status: 401,
-                    source: "/auth/admin/login",
-                    title: "Wrong password",
-                    detail: "Password is incorrect."
+                    source: req.path,
+                    title: "No token",
+                    detail: "No token provided in request headers"
                 }
             });
-        });
-    },
-
-    adminRegister: function() { // Register a new Admin
-
-    },
-
-    adminCheckToken: function() { // Check the x-access-token from admin (Not need for user bcs it uses passport)
-
+        }
+    
     }
 }
 

--- a/v1/models/auth.js
+++ b/v1/models/auth.js
@@ -158,7 +158,7 @@ const auth = {
             if (admin !== null) {
                 return res.status(401).json({
                     errors: {
-                        status: 401,
+                        status: 403,
                         source: "/auth/admin/register",
                         title: "Admin alredy created",
                         detail: "Admin with provided email is alredy created in database."

--- a/v1/models/auth.js
+++ b/v1/models/auth.js
@@ -127,6 +127,7 @@ const auth = {
         const adminFirstName = sanitize(body.firstName);
         const adminLastName = sanitize(body.lastName);
 
+        // If adminEmail or adminPassword is undefined
         if (!adminEmail || !adminPassword) {
             return res.status(401).json({
                 errors: {
@@ -136,7 +137,7 @@ const auth = {
                     detail: "Email or password missing in request"
                 }
             });
-        } else if (!adminFirstName || !adminLastName) {
+        } else if (!adminFirstName || !adminLastName) { // If adminFirstName or adminLastName is undefined
             return res.status(401).json({
                 errors: {
                     status: 401,
@@ -166,9 +167,10 @@ const auth = {
                 });
             }
 
+            // bcrypt the password
             bcrypt.hash(adminPassword, 10, async function(err, hash) {
                 if (err) {
-                    return res.status(500).json({
+                    return res.status(500).json({ // if error with bcrypt
                         errors: {
                             status: 500,
                             source: "/auth/admin/register",
@@ -178,6 +180,7 @@ const auth = {
                     });
                 }
     
+                // create a admin object
                 adminCreate = {
                     firstName: adminFirstName,
                     lastName: adminLastName,
@@ -185,12 +188,14 @@ const auth = {
                     password: hash,
                 }
     
+                // Insert the admin object to the database
                 let clientRegister = new MongoClient(mongoURI);
                 try {
                     let db = clientRegister.db("spark-rentals");
                     let admins_collection = db.collection("admins");
                     await admins_collection.insertOne(adminCreate);
 
+                    // Return sucess
                     return res.status(201).json({
                         data: {
                             message: "User successfully registered."
@@ -202,6 +207,7 @@ const auth = {
                     await clientRegister.close();
                 }
 
+                // if error with database
                 return res.status(500).json({
                     data: {
                         message: "Database error path: /auth/admin/register"
@@ -219,9 +225,9 @@ const auth = {
         let token = req.headers['x-access-token'];
 
         if (token) {
-            jwt.verify(token, jwtSecret, function(err, decoded) {
+            jwt.verify(token, jwtSecret, function(err, decoded) { // Verify the token
                 if (err) {
-                    return res.status(500).json({
+                    return res.status(500).json({ // If error response with error code 500
                         errors: {
                             status: 500,
                             source: req.path,
@@ -235,12 +241,12 @@ const auth = {
                 req.admin.api_key = decoded.api_key;
                 req.admin.email = decoded.email;
 
-                next();
+                next(); // sucess
 
                 return undefined;
             });
         } else {
-            return res.status(401).json({
+            return res.status(401).json({ // If no token in request headers response with error code 401
                 errors: {
                     status: 401,
                     source: req.path,

--- a/v1/route/auth.js
+++ b/v1/route/auth.js
@@ -5,4 +5,8 @@ const authModel = require("../models/auth.js");
 router.post('/admin/login',
     (req, res) => authModel.adminLogin(res, req.body));
 
+router.post('/admin',
+    (req, res, next) => authModel.adminCheckToken(req, res, next),
+    (req, res) => authModel.adminRegister(res, req.body));
+
 module.exports = router;


### PR DESCRIPTION
# Auth Admin
## Admin register
Implemented admin register. Need to be passing a admin x-access-token to register a new admin account.
If email or password not passed in request, repsonse: **Error code 401** with title: **Email or password missing.**
If first name or last name not passed in request, repsonse: **Error code 401** with title: **First name or last name missing.**
If admin alredy registered in database, response: **Error code 403** with title: **Admin alredy created.**
If problem with bcrypt, response: **Error  code 500** with title: **bcrypt error.**
If problem with database, response: **Error code 50**0 with message: **Database error path: /auth/admin/register.**
If everything goes alright, response: **Code 201** with message: **User successfully registered.**

## Admin check token
Implemented a authentication for checking jwt token ( x-access-token ).
If wrong token, response: **Error code 500** with title: **Failed authentication.**
If token is not passed in request headers, **Error code 401** with title: **No token.**
If everything goes alright, It goes to the next function ( Not sending any response bcs not needed ).

Auth check is for check if the token is correct when trying to get information form the REST API